### PR TITLE
Update and configure gatsby-plugin-purgecss.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -23,7 +23,16 @@ module.exports = {
     },
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',
-    'gatsby-plugin-purgecss',
+    {
+      // Removes unused css rules
+      resolve:'gatsby-plugin-purgecss',
+      options: {
+        // Activates purging in gatsby develop
+        develop: true,
+        // Purge only the main css file
+        purgeOnly: ['/all.sass'],
+      },
+    }, // must be after other CSS plugins
     'gatsby-plugin-netlify', // make sure to keep it last in the array
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-netlify-cms",
-  "version": "1.1.3",
+  "name": "gatsby-starter-wordpress",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -777,70 +777,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@emotion/babel-utils": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
-      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
-      "requires": {
-        "@emotion/hash": "^0.6.6",
-        "@emotion/memoize": "^0.6.6",
-        "@emotion/serialize": "^0.9.1",
-        "convert-source-map": "^1.5.1",
-        "find-root": "^1.1.0",
-        "source-map": "^0.7.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        }
-      }
-    },
-    "@emotion/hash": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ=="
-    },
-    "@emotion/is-prop-valid": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.6.8.tgz",
-      "integrity": "sha512-IMSL7ekYhmFlILXcouA6ket3vV7u9BqStlXzbKOF9HBtpUPMMlHU+bBxrLOa2NvleVwNIxeq/zL8LafLbeUXcA==",
-      "requires": {
-        "@emotion/memoize": "^0.6.6"
-      }
-    },
-    "@emotion/memoize": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ=="
-    },
-    "@emotion/serialize": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
-      "requires": {
-        "@emotion/hash": "^0.6.6",
-        "@emotion/memoize": "^0.6.6",
-        "@emotion/unitless": "^0.6.7",
-        "@emotion/utils": "^0.8.2"
-      }
-    },
-    "@emotion/stylis": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ=="
-    },
-    "@emotion/unitless": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg=="
-    },
-    "@emotion/utils": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1565,6 +1501,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
+    },
     "axobject-query": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.1.tgz",
@@ -1936,70 +1881,16 @@
         "babel-plugin-syntax-dynamic-import": "^6.18.0"
       }
     },
-    "babel-plugin-emotion": {
-      "version": "9.2.10",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.10.tgz",
-      "integrity": "sha512-ezELJPqCSA+FJ1XgUlOFbk1dilM+db610GdX81D+IBiqwEu9l1ifEP7oLslL3bew3LKT+PcbSltNBDvZACBe2g==",
+    "babel-plugin-lodash": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+      "integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/babel-utils": "^0.6.4",
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.7.0",
-        "babel-core": "^6.26.3",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "find-root": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.5.7",
-        "touch": "^2.0.1"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "6.26.3",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "@babel/helper-module-imports": "^7.0.0-beta.49",
+        "@babel/types": "^7.0.0-beta.49",
+        "glob": "^7.1.1",
+        "lodash": "^4.17.10",
+        "require-package-name": "^2.0.1"
       }
     },
     "babel-plugin-macros": {
@@ -3111,11 +3002,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -3429,15 +3315,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
-    "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -3505,11 +3382,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
       "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
-    },
-    "chain-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.1.tgz",
-      "integrity": "sha512-SxltgMwL9uCko5/ZCLiyG2B7R9fY4pDZUw7hJ4MhirdjBLosoDqkWABi3XMucddHdLiFJMb7PD2MZifZriuMTg=="
     },
     "chalk": {
       "version": "2.4.1",
@@ -3689,21 +3561,6 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
-        }
-      }
-    },
-    "clean-css": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
-      "requires": {
-        "source-map": "~0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -4048,11 +3905,6 @@
       "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
       "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ="
     },
-    "consolidated-events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-1.1.1.tgz",
-      "integrity": "sha1-JTlUZbNeUxOVQYt7vsteyvGY0Xk="
-    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -4156,35 +4008,6 @@
         "elliptic": "^6.0.0"
       }
     },
-    "create-emotion": {
-      "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.6.tgz",
-      "integrity": "sha512-4g46va26lw6DPfKF7HeWY3OI/qoaNSwpvO+li8dMydZfC6f6+ZffwlYHeIyAhGR8Z8C8c0H9J1pJbQRtb9LScw==",
-      "requires": {
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.6.10",
-        "@emotion/unitless": "^0.6.2",
-        "csstype": "^2.5.2",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10"
-      },
-      "dependencies": {
-        "@emotion/stylis": {
-          "version": "0.6.12",
-          "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.6.12.tgz",
-          "integrity": "sha512-yS+t7l5FeYeiIyADyqjFBJvdotpphHb2S3mP4qak5BpV7ODvxuyAVF24IchEslW+A1MWHAhn5SiOW6GZIumiEQ=="
-        }
-      }
-    },
-    "create-emotion-styled": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/create-emotion-styled/-/create-emotion-styled-9.2.8.tgz",
-      "integrity": "sha512-2LrNM5MREWzI5hZK+LyiBHglwE18WE3AEbBQgpHQ1+zmyLSm/dJsUZBeFAwuIMb+TjNZP0KsMZlV776ufOtFdg==",
-      "requires": {
-        "@emotion/is-prop-valid": "^0.6.1"
-      }
-    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -4216,16 +4039,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "create-react-context": {
@@ -4308,15 +4121,6 @@
       "requires": {
         "postcss": "^6.0.0",
         "timsort": "^0.3.0"
-      }
-    },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -5002,6 +4806,14 @@
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
     },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
@@ -5186,6 +4998,25 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deep-map": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/deep-map/-/deep-map-1.5.0.tgz",
+      "integrity": "sha1-6qWVy4F4PKKADyakLgnxbn1PuJA=",
+      "requires": {
+        "es6-weak-map": "^2.0.2",
+        "lodash": "^4.17.4",
+        "tslib": "^1.6.0"
+      }
+    },
+    "deep-map-keys": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/deep-map-keys/-/deep-map-keys-1.2.0.tgz",
+      "integrity": "sha1-Q0GLgoykPSYajod7SSfknQxHjNk=",
+      "requires": {
+        "es6-weak-map": "^2.0.1",
+        "lodash": "^4.13.1"
+      }
     },
     "deepmerge": {
       "version": "2.1.1",
@@ -5419,11 +5250,6 @@
         }
       }
     },
-    "diacritics": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
-      "integrity": "sha1-PvqHMj67hj5mls67AILUj/PW96E="
-    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -5451,27 +5277,6 @@
             "pify": "^3.0.0"
           }
         }
-      }
-    },
-    "direction": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
-      "integrity": "sha1-zl15f5fib4vnvv9T99xA4cGp7Ew="
-    },
-    "disposables": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.2.tgz",
-      "integrity": "sha1-NsamdEdfVaLWkTVnpgFETkh7S24="
-    },
-    "dnd-core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.6.0.tgz",
-      "integrity": "sha1-ErrWbVh0LG5ffPKUP7aFlED4CcQ=",
-      "requires": {
-        "asap": "^2.0.6",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "redux": "^3.7.1"
       }
     },
     "dns-equal": {
@@ -5738,15 +5543,6 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
-    "emotion": {
-      "version": "9.2.10",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.10.tgz",
-      "integrity": "sha512-DfFWB6Jc1y8PU1Dsi77tOyJPnY4jkVeT3EdJscccUXGDN27Y5vx591SWwFFbeOb+vOrKgA6f5gMtPkutae84xg==",
-      "requires": {
-        "babel-plugin-emotion": "^9.2.10",
-        "create-emotion": "^9.2.6"
-      }
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5912,10 +5708,50 @@
         "is-symbol": "^1.0.1"
       }
     },
+    "es5-ext": {
+      "version": "0.10.48",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz",
+      "integrity": "sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -6009,6 +5845,45 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        }
+      }
+    },
+    "eslint-config-airbnb": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.0.tgz",
+      "integrity": "sha512-R9jw28hFfEQnpPau01NO5K/JWMGLi6aymiF6RsnMURjTk+MqZKllCqGK/0tOvHkPi/NWSSOU2Ced/GX++YxLnw==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^13.1.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.1.0.tgz",
+      "integrity": "sha512-XWwQtf3U3zIoKO1BbHh6aUhJZQweOwSt4c2JrPDg9FP3Ltv3+YfEv7jIDB8275tVnO/qOHbfuYg3kzw6Je7uWw==",
+      "dev": true,
+      "requires": {
+        "eslint-restricted-globals": "^0.1.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.0.4"
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz",
+      "integrity": "sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
         }
       }
     },
@@ -6190,6 +6065,12 @@
         "prop-types": "^15.6.2"
       }
     },
+    "eslint-restricted-globals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
+      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
@@ -6233,11 +6114,6 @@
       "requires": {
         "estraverse": "^4.1.0"
       }
-    },
-    "esrever": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/esrever/-/esrever-0.2.0.tgz",
-      "integrity": "sha1-lunSj08bGnZ4TNXUkOquAQ50B7g="
     },
     "estraverse": {
       "version": "4.2.0",
@@ -6879,11 +6755,6 @@
         "pkg-dir": "^2.0.0"
       }
     },
-    "find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
-    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -6981,11 +6852,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.4"
       }
-    },
-    "focus-group": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/focus-group/-/focus-group-0.3.1.tgz",
-      "integrity": "sha1-4PMu2GsNq91v/OvfiY7LMuR/7c4="
     },
     "follow-redirects": {
       "version": "1.5.8",
@@ -7188,7 +7054,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7206,11 +7073,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7223,15 +7092,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7334,7 +7206,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7344,6 +7217,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7356,17 +7230,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7383,6 +7260,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7455,7 +7333,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7465,6 +7344,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7540,7 +7420,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7570,6 +7451,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7587,6 +7469,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7625,11 +7508,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7661,11 +7546,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
-    },
-    "fuzzy": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/fuzzy/-/fuzzy-0.1.3.tgz",
-      "integrity": "sha1-THbsL/CsGjap3M+aAN+GIweNTtg="
     },
     "gatsby": {
       "version": "2.0.7",
@@ -7829,6 +7709,14 @@
         }
       }
     },
+    "gatsby-awesome-pagination": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/gatsby-awesome-pagination/-/gatsby-awesome-pagination-0.3.4.tgz",
+      "integrity": "sha512-OLO/tdD+jh7gzxeRRWUJ8Iy5NXKBBUnxTi8t9QC/Gy1tcnoIyBzO3vQFMTCkXoNP7RY5US8aiHtt7mcQfAVMQA==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "gatsby-link": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.0.1.tgz",
@@ -7839,6 +7727,16 @@
         "@types/reach__router": "^1.0.0",
         "prop-types": "^15.6.1",
         "ric": "^1.3.0"
+      }
+    },
+    "gatsby-plugin-lodash": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-lodash/-/gatsby-plugin-lodash-3.0.4.tgz",
+      "integrity": "sha512-XQJdDl98ogG0OD7vHtG45oWKOKTIMP2G/Cm+uvEQoDZnFdUM8sn4k9eg6+JGggqBRBkIz+vazEGZoPKIP21log==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "babel-plugin-lodash": "^3.2.11",
+        "lodash-webpack-plugin": "^0.11.5"
       }
     },
     "gatsby-plugin-netlify": {
@@ -7863,20 +7761,6 @@
             "universalify": "^0.1.0"
           }
         }
-      }
-    },
-    "gatsby-plugin-netlify-cms": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-3.0.2.tgz",
-      "integrity": "sha512-CUmsSkdkN/oiYAJ1QDiwVU2f16ASHgDW+cEWSVvqtAdtQMFoGNOjUlr7KBrZI4Jp1JxTZFN009vuje0PT+omQg==",
-      "requires": {
-        "friendly-errors-webpack-plugin": "^1.7.0",
-        "html-webpack-exclude-assets-plugin": "^0.0.7",
-        "html-webpack-plugin": "^3.2.0",
-        "lodash": "^4.17.10",
-        "mini-css-extract-plugin": "^0.4.1",
-        "netlify-identity-widget": "^1.4.11",
-        "webpack": "^4.16.0"
       }
     },
     "gatsby-plugin-page-creator": {
@@ -8005,6 +7889,28 @@
             "object.omit": "^2.0.0",
             "parse-glob": "^3.0.4",
             "regex-cache": "^0.4.2"
+          }
+        }
+      }
+    },
+    "gatsby-plugin-purgecss": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-3.1.0.tgz",
+      "integrity": "sha512-X8715ZuRmusyEIE91EA+4SS3yvw986kV0h4atB6Tsz5rE8n9KqzPMQxrVsJGRuI5DIxu0YZN6EEFlb7UMTT3cg==",
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "loader-utils": "^1.1.0",
+        "purgecss": "^1.0.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         }
       }
@@ -8286,6 +8192,579 @@
         }
       }
     },
+    "gatsby-source-wordpress": {
+      "version": "3.0.43",
+      "resolved": "https://registry.npmjs.org/gatsby-source-wordpress/-/gatsby-source-wordpress-3.0.43.tgz",
+      "integrity": "sha512-0aDBDUBpCMDxZ6H71Jrju84cIWKMMPisp0hMJVWjmrYI7rgFzVnxvDVE0FcyL42iy+9G31FI4y4tlNVOeGcdzg==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "axios": "^0.18.0",
+        "better-queue": "^3.8.6",
+        "bluebird": "^3.5.0",
+        "deep-map": "^1.5.0",
+        "deep-map-keys": "^1.2.0",
+        "gatsby-source-filesystem": "^2.0.23",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.10",
+        "minimatch": "^3.0.4",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "chokidar": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+          "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.0"
+          }
+        },
+        "file-type": {
+          "version": "10.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.9.0.tgz",
+          "integrity": "sha512-9C5qtGR/fNibHC5gzuMmmgnjH3QDDLKMa8lYe9CiZVmAnI4aUaoMh40QyUPzzs0RYo837SOBKh7TYwle4G8E4w=="
+        },
+        "fsevents": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+          "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.2.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.10.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "gatsby-source-filesystem": {
+          "version": "2.0.23",
+          "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.0.23.tgz",
+          "integrity": "sha512-gzcvKTysWgCIFEp9WyKqFGJsF6Cb+MNDX7dRzB3vmS3c/mJi+/UbOuxcqLuNSGhONskTVh3N57kbvcqMq/f8Jg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "better-queue": "^3.8.7",
+            "bluebird": "^3.5.0",
+            "chokidar": "^2.1.2",
+            "file-type": "^10.2.0",
+            "fs-extra": "^5.0.0",
+            "got": "^7.1.0",
+            "md5-file": "^3.1.1",
+            "mime": "^2.2.0",
+            "pretty-bytes": "^4.0.2",
+            "progress": "^1.1.8",
+            "read-chunk": "^3.0.0",
+            "slash": "^1.0.0",
+            "valid-url": "^1.0.9",
+            "xstate": "^3.1.0"
+          }
+        },
+        "got": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+          "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+          "requires": {
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "read-chunk": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.1.0.tgz",
+          "integrity": "sha512-ZdiZJXXoZYE08SzZvTipHhI+ZW0FpzxmFtLI3vIeMuRN9ySbIZ+SZawKogqJ7dxW9fJ/W73BNtxu4Zu/bZp+Ng==",
+          "requires": {
+            "pify": "^4.0.1",
+            "with-open-file": "^0.1.5"
+          }
+        }
+      }
+    },
     "gatsby-transformer-remark": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.1.3.tgz",
@@ -8385,11 +8864,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
-    "get-document": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz",
-      "integrity": "sha1-SCG85m8cJMsDMWAr5strEsTwHEs="
-    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -8417,14 +8891,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-    },
-    "get-window": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-window/-/get-window-1.1.2.tgz",
-      "integrity": "sha512-yjWpFcy9fjhLQHW1dPtg9ga4pmizLY8y4ZSHdGrAQ1NU277MRhnGnnLPxe19X8W5lWVsCZz++5xEuNozWMVmTw==",
-      "requires": {
-        "get-document": "1"
-      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -8759,14 +9225,6 @@
         "timed-out": "^4.0.0",
         "unzip-response": "^2.0.1",
         "url-parse-lax": "^1.0.0"
-      }
-    },
-    "gotrue-js": {
-      "version": "0.9.22",
-      "resolved": "https://registry.npmjs.org/gotrue-js/-/gotrue-js-0.9.22.tgz",
-      "integrity": "sha512-i7onzXLP41YHs/S6LFk7mactBSIBb/Xib1dsvYMYu4e45HVLJlEYW1u016DVbh5mMFtyCace6QUbC7lHpG/hNw==",
-      "requires": {
-        "micro-api-client": "^3.2.1"
       }
     },
     "graceful-fs": {
@@ -9375,14 +9833,6 @@
         "unist-util-is": "^2.0.0"
       }
     },
-    "hast-util-embedded": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-1.0.1.tgz",
-      "integrity": "sha512-VreBCMxmSRCT7OjZihrth3ByA9GtLKbRyoDJafP/1vxAxx+VNdhHKKADCSIyMGvrvTExVRqU/BnVq51dxMLAeQ==",
-      "requires": {
-        "hast-util-is-element": "^1.0.0"
-      }
-    },
     "hast-util-from-parse5": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-2.1.0.tgz",
@@ -9399,20 +9849,6 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
-      }
-    },
-    "hast-util-has-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.1.tgz",
-      "integrity": "sha512-DUck5lp8ku3o8n9GIA1Nghdz8UQyis2/b/ro0O4z5HP/y82uzZL6CXehuQmY5re+rLgTP4MVF/YpYDj9YqD0wA=="
-    },
-    "hast-util-is-body-ok-link": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.1.tgz",
-      "integrity": "sha512-qFDY0oz0lbc0DOcy61BSgJo+wi/ykFs4p95YjrtRP81eNfmBPs/Z0j4WLFmepJ6znfxLlRcPpic8FOdzCD5aKw==",
-      "requires": {
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0"
       }
     },
     "hast-util-is-element": {
@@ -9457,20 +9893,6 @@
         "xtend": "^4.0.1"
       }
     },
-    "hast-util-to-mdast": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-1.2.0.tgz",
-      "integrity": "sha512-kYrD+weqqtBwqLHkEMh12YHXPzG1iuRm9NH3qVs7hwGTkE5QrhtdMahVN96JnRnb/MmdvfKCzK42ajgRKjQzNg==",
-      "requires": {
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "hast-util-to-string": "^1.0.0",
-        "rehype-minify-whitespace": "^2.0.0",
-        "unist-util-is": "^2.1.0",
-        "unist-util-visit": "^1.1.1",
-        "xtend": "^4.0.1"
-      }
-    },
     "hast-util-to-parse5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-2.2.0.tgz",
@@ -9482,11 +9904,6 @@
         "xtend": "^4.0.1",
         "zwitch": "^1.0.0"
       }
-    },
-    "hast-util-to-string": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.1.tgz",
-      "integrity": "sha512-EC6awGe0ZMUNYmS2hMVaKZxvjVtQA4RhXjtgE20AxGG49MM7OUUfaHc6VcVYv2YwzNlrZQGe5teimCxW1Rk+fA=="
     },
     "hast-util-whitespace": {
       "version": "1.0.1",
@@ -9512,27 +9929,10 @@
         }
       }
     },
-    "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-    },
     "hex-color-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
-    },
-    "history": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
-      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
-      "requires": {
-        "invariant": "^2.2.1",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
-      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -9607,82 +10007,10 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
-    "html-minifier": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.20.tgz",
-      "integrity": "sha512-ZmgNLaTp54+HFKkONyLFEfs5dd/ZOtlquKaTnqIWFmx3Av5zG6ZPcV2d0o9XM2fXOTxxIf6eDcwzFFotke/5zA==",
-      "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.2.x",
-        "commander": "2.17.x",
-        "he": "1.1.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "uglify-js": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-          "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-          "requires": {
-            "commander": "~2.17.1",
-            "source-map": "~0.6.1"
-          }
-        }
-      }
-    },
     "html-void-elements": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.3.tgz",
       "integrity": "sha512-SaGhCDPXJVNrQyKMtKy24q6IMdXg5FCPN3z+xizxw9l+oXQw5fOoaj/ERU5KqWhSYhXtW5bWthlDbTDLBhJQrA=="
-    },
-    "html-webpack-exclude-assets-plugin": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/html-webpack-exclude-assets-plugin/-/html-webpack-exclude-assets-plugin-0.0.7.tgz",
-      "integrity": "sha512-gaYKMGBPDts3Fb1WXyDEEcS/0TSRg2IDl3EsbQL2AkKWTqdjSKwfQ8Iz0RhPiWErJfqhq5/wkhoYyjQoG55pug=="
-    },
-    "html-webpack-plugin": {
-      "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
-      "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
-      "requires": {
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "tapable": "^1.0.0",
-        "toposort": "^1.0.0",
-        "util.promisify": "1.0.0"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
-          }
-        }
-      }
-    },
-    "html-whitespace-sensitive-tag-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-1.0.0.tgz",
-      "integrity": "sha1-/W7To9Yxzik0Gu/iao/qcg0636c="
     },
     "htmlnano": {
       "version": "0.1.10",
@@ -10188,11 +10516,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
-    "hyphenate-style-name": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -10306,11 +10629,6 @@
         "exec-buffer": "^3.0.0",
         "is-cwebp-readable": "^2.0.1"
       }
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immutable": {
       "version": "3.7.6",
@@ -10448,15 +10766,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "inline-style-prefixer": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-      "requires": {
-        "bowser": "^1.7.3",
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "inquirer": {
       "version": "3.3.0",
@@ -10709,11 +11018,6 @@
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
     },
-    "is-empty": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
-      "integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s="
-    },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
@@ -10767,16 +11071,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
       "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
-    },
-    "is-hotkey": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.3.tgz",
-      "integrity": "sha512-wB5PP/lwpaN5zNT1vjHxYFBxiq5zvUZiv8696eB5OmeCRCgNIzb3cMJjRhogSQXe8LLDKOzzlFfGlMaWnc4emQ=="
-    },
-    "is-in-browser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -10990,11 +11284,6 @@
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
       "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
     },
-    "is-window": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
-      "integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0="
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -11037,11 +11326,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-    },
-    "isomorphic-base64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz",
-      "integrity": "sha1-9Caq6CVpuopOxcpzrSGkSrHueAM="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -11266,11 +11550,6 @@
         "array-includes": "^3.0.3"
       }
     },
-    "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
-    },
     "kebab-case": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
@@ -11283,11 +11562,6 @@
       "requires": {
         "lodash.kebabcase": "^4.1.1"
       }
-    },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
     },
     "killable": {
       "version": "1.0.1",
@@ -11349,14 +11623,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "requires": {
-        "immediate": "~3.0.5"
       }
     },
     "load-bmfont": {
@@ -11466,14 +11732,6 @@
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
         "json5": "^0.5.0"
-      }
-    },
-    "localforage": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.2.tgz",
-      "integrity": "sha1-+kRCYC+Abt0rympUq05lbwMfEhw=",
-      "requires": {
-        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -11775,11 +12033,6 @@
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
       }
-    },
-    "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -12139,11 +12392,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "micro-api-client": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/micro-api-client/-/micro-api-client-3.3.0.tgz",
-      "integrity": "sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg=="
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -12498,380 +12746,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
       "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw=="
     },
-    "netlify-cms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/netlify-cms/-/netlify-cms-2.1.2.tgz",
-      "integrity": "sha512-+LaJphsnc9/CeCaHnfW78GwpRqM1TG8D20MZkBWYa1vxBbn6TpNWMjuK0JcJEkLXFoLH8QFgjgQ81j6QvnZZxA==",
-      "requires": {
-        "emotion": "^9.2.6",
-        "netlify-cms-backend-bitbucket": "^2.0.7",
-        "netlify-cms-backend-git-gateway": "^2.0.8",
-        "netlify-cms-backend-github": "^2.0.9",
-        "netlify-cms-backend-gitlab": "^2.0.6",
-        "netlify-cms-backend-test": "^2.0.6",
-        "netlify-cms-core": "^2.1.0",
-        "netlify-cms-editor-component-image": "^2.0.4",
-        "netlify-cms-media-library-uploadcare": "^0.2.0",
-        "netlify-cms-widget-boolean": "^2.0.4",
-        "netlify-cms-widget-date": "^2.0.5",
-        "netlify-cms-widget-datetime": "^2.0.5",
-        "netlify-cms-widget-file": "^2.1.0",
-        "netlify-cms-widget-image": "^2.1.0",
-        "netlify-cms-widget-list": "^2.0.6",
-        "netlify-cms-widget-markdown": "^2.0.8",
-        "netlify-cms-widget-number": "^2.0.5",
-        "netlify-cms-widget-object": "^2.0.5",
-        "netlify-cms-widget-relation": "^2.0.5",
-        "netlify-cms-widget-select": "^2.0.4",
-        "netlify-cms-widget-string": "^2.0.4",
-        "netlify-cms-widget-text": "^2.0.5"
-      }
-    },
-    "netlify-cms-backend-bitbucket": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-bitbucket/-/netlify-cms-backend-bitbucket-2.0.7.tgz",
-      "integrity": "sha512-kioEzSqF0wXJeJJDlmwuTDeoz+2zQIzFQiSQkCgZSg/qx3cjgqiD0194pmTevPGirroyxyudHPWdpB8ZmkBlUg==",
-      "requires": {
-        "js-base64": "^2.4.8",
-        "semaphore": "^1.1.0"
-      }
-    },
-    "netlify-cms-backend-git-gateway": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-git-gateway/-/netlify-cms-backend-git-gateway-2.0.8.tgz",
-      "integrity": "sha512-3mcqPWVXnU3KLgCXzl1RDTFbZlbfjHwhDtoJZ0D7oG1sDss1zRXqhIW/nbr6baM5fUSmwUrwgiQcDVy+WS3KJg==",
-      "requires": {
-        "gotrue-js": "^0.9.22",
-        "jwt-decode": "^2.2.0"
-      }
-    },
-    "netlify-cms-backend-github": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-github/-/netlify-cms-backend-github-2.0.9.tgz",
-      "integrity": "sha512-xOkrtnLHHAcNWVOgnqcY6+Gpup0tubY84OIGeASFJEnkAjWA1WLW3QJ5dq5IGOYZvDLXRJanYM1gFpKl0IDgnQ==",
-      "requires": {
-        "js-base64": "^2.4.8",
-        "semaphore": "^1.1.0"
-      }
-    },
-    "netlify-cms-backend-gitlab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-gitlab/-/netlify-cms-backend-gitlab-2.0.6.tgz",
-      "integrity": "sha512-+bS9/W88HlO049V3bLJtTj1GRMmhPhNX4U376E29wp2KRvIzLfd4S/O68Y6AvusvyXETC7hzFpS5i3b97SItEw==",
-      "requires": {
-        "js-base64": "^2.4.8",
-        "semaphore": "^1.1.0"
-      }
-    },
-    "netlify-cms-backend-test": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-backend-test/-/netlify-cms-backend-test-2.0.6.tgz",
-      "integrity": "sha512-XXDI8fXCXRTjVD8Rz9rd/+v/FpzOze+xc2wi9HM9sntMhoDgIJbqdkS1CYJ0iF+zswhmv+h4Qb0r4aHl5+Dv0Q==",
-      "requires": {
-        "uuid": "^3.3.2"
-      }
-    },
-    "netlify-cms-core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-core/-/netlify-cms-core-2.1.0.tgz",
-      "integrity": "sha512-WNwd/F68DDQjfadSJI1t+e8dPkoqO+pvsUMZiYW6aS63xv19YdqtmAr9sQiwfitrnGPZtLyH6hPr1vHQxHet4Q==",
-      "requires": {
-        "ajv": "^6.4.0",
-        "ajv-errors": "^1.0.0",
-        "create-react-class": "^15.6.0",
-        "diacritics": "^1.3.0",
-        "emotion": "^9.2.6",
-        "fuzzy": "^0.1.1",
-        "gotrue-js": "^0.9.15",
-        "gray-matter": "^3.0.6",
-        "history": "^4.7.2",
-        "immutable": "^3.7.6",
-        "js-base64": "^2.1.9",
-        "js-yaml": "^3.10.0",
-        "jwt-decode": "^2.1.0",
-        "lodash": "^4.17.10",
-        "moment": "^2.11.2",
-        "netlify-cms-editor-component-image": "^2.0.4",
-        "netlify-cms-lib-auth": "^2.0.4",
-        "netlify-cms-lib-util": "^2.1.0",
-        "netlify-cms-ui-default": "^2.0.6",
-        "prop-types": "^15.5.10",
-        "react": "^16.4.1",
-        "react-dnd": "^2.5.4",
-        "react-dnd-html5-backend": "^2.5.4",
-        "react-dom": "^16.0.0",
-        "react-emotion": "^9.2.5",
-        "react-frame-component": "^2.0.0",
-        "react-hot-loader": "^4.0.0",
-        "react-immutable-proptypes": "^2.1.0",
-        "react-is": "16.3.1",
-        "react-modal": "^3.1.5",
-        "react-redux": "^4.4.0",
-        "react-router-dom": "^4.2.2",
-        "react-router-redux": "^5.0.0-alpha.8",
-        "react-scroll-sync": "^0.6.0",
-        "react-sortable-hoc": "^0.6.8",
-        "react-split-pane": "^0.1.82",
-        "react-topbar-progress-indicator": "^2.0.0",
-        "react-waypoint": "^7.1.0",
-        "redux": "^3.3.1",
-        "redux-notifications": "^4.0.1",
-        "redux-optimist": "^0.0.2",
-        "redux-thunk": "^1.0.3",
-        "sanitize-filename": "^1.6.1",
-        "semaphore": "^1.0.5",
-        "toml-j0.4": "^1.1.1",
-        "tomlify-j0.4": "^3.0.0-alpha.0",
-        "url": "^0.11.0",
-        "what-input": "^5.0.3"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-          "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "gray-matter": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
-          "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "js-yaml": "^3.10.0",
-            "kind-of": "^5.0.2",
-            "strip-bom-string": "^1.0.0"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
-    "netlify-cms-editor-component-image": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-editor-component-image/-/netlify-cms-editor-component-image-2.0.4.tgz",
-      "integrity": "sha512-2JMsgXs6+sTVnXezCgm8j/Y9kYpPd+FjKHeGxTZzvnkaSp6vj0I3Gcz2MIBuUDls3uOf1ZmD6BzUp0K2kJzx2g=="
-    },
-    "netlify-cms-lib-auth": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-lib-auth/-/netlify-cms-lib-auth-2.0.4.tgz",
-      "integrity": "sha512-9pkUW9WFpPyokKTW+q2H8MsOojS5ELmB1fraFIudXRSv/uZ4y9wbiYIpbhplA0Ra6ErbWcbJUh1Ww7fE7C7WpQ==",
-      "requires": {
-        "uuid": "^3.1.0"
-      }
-    },
-    "netlify-cms-lib-util": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-lib-util/-/netlify-cms-lib-util-2.1.0.tgz",
-      "integrity": "sha512-Cm0/5wziVzDsnUpclFS87nxhqQYTTpARb4g1cGbocI+RUimMA1vQ+RqB3Cup6QuGu1ESROL3Cr7qo4Z/Gjoxmg==",
-      "requires": {
-        "localforage": "^1.4.2"
-      }
-    },
-    "netlify-cms-media-library-uploadcare": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-media-library-uploadcare/-/netlify-cms-media-library-uploadcare-0.2.0.tgz",
-      "integrity": "sha512-UNBkDOI36lDTl6dx0ojsB6EqCPd7dTzlhM02lWR2+g30CQ+bg6yylgs1eoQPihI4+wsHochs2/cbXuSIiM6/9g=="
-    },
-    "netlify-cms-ui-default": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-ui-default/-/netlify-cms-ui-default-2.0.6.tgz",
-      "integrity": "sha512-6S+uVs3es9+/WAZw815oBTWl0rr4sybBKAsx9Mxe72/mcQ+YP88iDOTw2XoiNu0gxWceM1s+awFI9naFDMl4HA==",
-      "requires": {
-        "react-aria-menubutton": "^5.1.0",
-        "react-toggled": "^1.1.2",
-        "react-transition-group": "^2.2.1"
-      }
-    },
-    "netlify-cms-widget-boolean": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-boolean/-/netlify-cms-widget-boolean-2.0.4.tgz",
-      "integrity": "sha512-oh/Kxmj6QMwdgtJ57bHTk1oACnMDwMQbrcxSTmP0bJdgx7pe06RusJ63Lzdsri3XrUvZU+xnenrx1XpgfLO84g=="
-    },
-    "netlify-cms-widget-date": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-date/-/netlify-cms-widget-date-2.0.5.tgz",
-      "integrity": "sha512-08PQQ3O/LaxuTpaG7JC8O2S+yRnfSQYmOoTOYayfakl6wcQbZUMZ94ZUxZwLpac9vNTwfb2XSs/frw9vaJTm0w==",
-      "requires": {
-        "react-datetime": "^2.11.0"
-      }
-    },
-    "netlify-cms-widget-datetime": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-datetime/-/netlify-cms-widget-datetime-2.0.5.tgz",
-      "integrity": "sha512-o+aO9oMhu9NPDSvib7uuHeXt182rfv8MwA5FfLwNef1oFU0cZAtPZz+tMI7EM6QSWTNULWaRj5azy9FnLQtDsg==",
-      "requires": {
-        "netlify-cms-widget-date": "^2.0.5"
-      }
-    },
-    "netlify-cms-widget-file": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-file/-/netlify-cms-widget-file-2.1.0.tgz",
-      "integrity": "sha512-JAiI/HaWVNelm79eEdadu6ej7ZJaWKC0oBwlZYtCFQvAwZ1pQrHzH+6IY7OqnCOTPdC7otM78VE0oLz0/twc/A==",
-      "requires": {
-        "uuid": "^3.3.2"
-      }
-    },
-    "netlify-cms-widget-image": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-image/-/netlify-cms-widget-image-2.1.0.tgz",
-      "integrity": "sha512-vHNAfVX6x5I5M36ojLDk6LG5rjDzZzO48nf3f2AANEaERr4y53+Kf/Fsu3QNIuV/liEc9MICgKA0Tt9TMKDLBg==",
-      "requires": {
-        "netlify-cms-widget-file": "^2.1.0"
-      }
-    },
-    "netlify-cms-widget-list": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-list/-/netlify-cms-widget-list-2.0.6.tgz",
-      "integrity": "sha512-cBmE2CTBZax4VMBNdOYui3N90+CiDsaO6VprsOGsN4k7IGVb3kVq2EO2O8ymQEkUlPEItEs+YYkVo1yeb+w9vA==",
-      "requires": {
-        "netlify-cms-widget-object": "^2.0.5",
-        "react-sortable-hoc": "^0.6.8"
-      }
-    },
-    "netlify-cms-widget-markdown": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-markdown/-/netlify-cms-widget-markdown-2.0.8.tgz",
-      "integrity": "sha512-ekk2uSqiAnEpZ2i4HLrD+wj8eMtq0xkpHrhrfvsSszbJfmirlfp4YJ/61H7noztRwE5PWICrNo3N0/41PFNOGA==",
-      "requires": {
-        "is-hotkey": "^0.1.1",
-        "mdast-util-definitions": "^1.2.2",
-        "mdast-util-to-string": "^1.0.4",
-        "rehype-parse": "^3.1.0",
-        "rehype-remark": "^2.0.0",
-        "rehype-stringify": "^3.0.0",
-        "remark-parse": "^3.0.1",
-        "remark-rehype": "^2.0.0",
-        "remark-stringify": "^3.0.1",
-        "slate": "^0.34.0",
-        "slate-edit-list": "^0.11.3",
-        "slate-edit-table": "^0.15.1",
-        "slate-plain-serializer": "^0.5.15",
-        "slate-react": "0.12.9",
-        "slate-soft-break": "^0.6.1",
-        "unified": "^6.1.4",
-        "unist-builder": "^1.0.2",
-        "unist-util-visit-parents": "^1.1.1"
-      },
-      "dependencies": {
-        "remark-parse": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-3.0.1.tgz",
-          "integrity": "sha1-G5+EGkTY9PvyJGhQJlRZpOs1TIA=",
-          "requires": {
-            "collapse-white-space": "^1.0.2",
-            "has": "^1.0.1",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "remark-stringify": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-3.0.1.tgz",
-          "integrity": "sha1-eSQr6+CnUggbWAlRb6DAbt7Aac8=",
-          "requires": {
-            "ccount": "^1.0.0",
-            "is-alphanumeric": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "longest-streak": "^2.0.1",
-            "markdown-escapes": "^1.0.0",
-            "markdown-table": "^1.1.0",
-            "mdast-util-compact": "^1.0.0",
-            "parse-entities": "^1.0.2",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "stringify-entities": "^1.0.1",
-            "unherit": "^1.0.4",
-            "xtend": "^4.0.1"
-          }
-        },
-        "unist-util-visit-parents": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
-          "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
-        }
-      }
-    },
-    "netlify-cms-widget-number": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-number/-/netlify-cms-widget-number-2.0.5.tgz",
-      "integrity": "sha512-43m6+c81ugCEjpJB38esTE/Asmc6l6QgAtmY7r/lUWSNx2m6hgA73afeNa+/RN5LmHZNiF1sN334bqYZ+Q7Q+w=="
-    },
-    "netlify-cms-widget-object": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-object/-/netlify-cms-widget-object-2.0.5.tgz",
-      "integrity": "sha512-fAoExkhi0uq63NszO3Z0D8VzMjJ1cl0u82gad47bzL7nfaVdjfqZ/IubNL4/70isL+xL9W5yqtsiKoxhB0ur1A=="
-    },
-    "netlify-cms-widget-relation": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-relation/-/netlify-cms-widget-relation-2.0.5.tgz",
-      "integrity": "sha512-qCe92K00FaWe3FBf3BmqglVuS8rvjqIXivo2FEPDd7fCjTG9LboNbWiAuvTWFn7to5miOXeT2qWHVnYmI6Qw2Q==",
-      "requires": {
-        "react-autosuggest": "^9.3.2"
-      }
-    },
-    "netlify-cms-widget-select": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-select/-/netlify-cms-widget-select-2.0.4.tgz",
-      "integrity": "sha512-MtrgjnMAa87lYXKNsEu8/kgKfs+h1Vd3mVc38pjP+Khc6xkYRFEcVn3T3u90hVPpJUajhYprJf31+wIw+ovgvg=="
-    },
-    "netlify-cms-widget-string": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-string/-/netlify-cms-widget-string-2.0.4.tgz",
-      "integrity": "sha512-JKCLnR/RYqIrpQFC4sqJp2KAW2PjmhOf57YpHcSLzjUhvMPXgO1hImMQfGwtOj8mvUOVvUm0P0fCbBj0vSVrNA=="
-    },
-    "netlify-cms-widget-text": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/netlify-cms-widget-text/-/netlify-cms-widget-text-2.0.5.tgz",
-      "integrity": "sha512-m3ZnBQ3j971e3qPibD2uxcK4rKQVE5Da9UDrPMsixTcR5SdpnYeaTjwk1eQIr8KE0s0XMZipsVOSQqRN8pAbFA==",
-      "requires": {
-        "react-textarea-autosize": "^5.2.0"
-      }
-    },
-    "netlify-identity-widget": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/netlify-identity-widget/-/netlify-identity-widget-1.4.14.tgz",
-      "integrity": "sha512-F2wAEgfJDjtNcV9vt+GlishUgi2q5IJoeP1VLEZwH9Kq4vUunZByR/2R5Bb6XpCLuiXoT0hNY7zUMCxGBKbl6Q=="
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -12886,14 +12760,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.2.tgz",
       "integrity": "sha512-DV7wVvMcAsmZ5qEwvX1JUNF4lKkAAKbChwNlIH7NLsPR7LWWoeIt53YlZ5CQH5KDXEXQ9Xa3mw0PbPewymrtew=="
-    },
-    "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
-      "requires": {
-        "lower-case": "^1.1.1"
-      }
     },
     "node-abi": {
       "version": "2.4.4",
@@ -13184,14 +13050,6 @@
       "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
       "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
     },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -13341,6 +13199,30 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
       }
     },
     "object.getownpropertydescriptors": {
@@ -13653,14 +13535,6 @@
         "cyclist": "~0.2.2",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
-      }
-    },
-    "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "requires": {
-        "no-case": "^2.2.0"
       }
     },
     "parcel-bundler": {
@@ -15244,6 +15118,220 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "purgecss": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-1.1.0.tgz",
+      "integrity": "sha512-/XYpiMvbehpeJqxu8k0hzCai9F2RQGjprjpJzRMq9e2qkT8Fk7AW9zLr7bAuqQfxgMIV/+DTNlks3Ckn6J9WEw==",
+      "requires": {
+        "glob": "^7.1.2",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^5.0.0-rc.3",
+        "yargs": "^12.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+          "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-is-promise": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+          "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "postcss": {
+          "version": "7.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
+          "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -15407,54 +15495,6 @@
         "schedule": "^0.5.0"
       }
     },
-    "react-aria-menubutton": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/react-aria-menubutton/-/react-aria-menubutton-5.1.1.tgz",
-      "integrity": "sha512-ceBjPvuqwM2jnRFsfMlpfPdyqQ5cz4STNH7NlKpxStr2uETB/zQ2sHiIUMTuqSuOszU1kgUB2vm3aVn3xdjhcA==",
-      "requires": {
-        "focus-group": "^0.3.1",
-        "prop-types": "^15.6.0",
-        "teeny-tap": "^0.2.0"
-      }
-    },
-    "react-autosuggest": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/react-autosuggest/-/react-autosuggest-9.4.2.tgz",
-      "integrity": "sha512-GkLFnr+79DtDFMNxbjKzTKEwOfItw2mKiCNTD3bE+gZSPf5Y+i+W+8KySmBnDWFPF5cuJeuBhQBgcSdbp45nAg==",
-      "requires": {
-        "prop-types": "^15.5.10",
-        "react-autowhatever": "^10.1.2",
-        "shallow-equal": "^1.0.0"
-      }
-    },
-    "react-autowhatever": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/react-autowhatever/-/react-autowhatever-10.1.2.tgz",
-      "integrity": "sha512-+0XgELT1LF7hHEJv5H5Zwkfb4Q1rqmMZZ5U/XJ2J+UcSPRKnG6CqEjXUJ+hYLXDHgvDqwEN5PBdxczD5rHvOuA==",
-      "requires": {
-        "prop-types": "^15.5.8",
-        "react-themeable": "^1.1.0",
-        "section-iterator": "^2.0.0"
-      }
-    },
-    "react-datetime": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/react-datetime/-/react-datetime-2.15.0.tgz",
-      "integrity": "sha512-RP5OqXVfrhdoFALJzMU8tKxRFaIZzJZqZEpf5oK7pvwG80a/bET/TdJ7jT7W9lyAf1nKNo6zyYkvHW3ZJ/ypvg==",
-      "requires": {
-        "create-react-class": "^15.5.2",
-        "object-assign": "^3.0.0",
-        "prop-types": "^15.5.7",
-        "react-onclickoutside": "^6.5.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
-      }
-    },
     "react-dev-utils": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-4.2.2.tgz",
@@ -15534,27 +15574,6 @@
         }
       }
     },
-    "react-dnd": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-2.6.0.tgz",
-      "integrity": "sha1-f6JWds+CfViokSk+PBq1naACVFo=",
-      "requires": {
-        "disposables": "^1.0.1",
-        "dnd-core": "^2.6.0",
-        "hoist-non-react-statics": "^2.1.0",
-        "invariant": "^2.1.0",
-        "lodash": "^4.2.0",
-        "prop-types": "^15.5.10"
-      }
-    },
-    "react-dnd-html5-backend": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-2.6.0.tgz",
-      "integrity": "sha1-WQzRzKeEQbsnTt1XH+9MCxbdz44=",
-      "requires": {
-        "lodash": "^4.2.0"
-      }
-    },
     "react-dom": {
       "version": "16.5.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.5.2.tgz",
@@ -15566,24 +15585,10 @@
         "schedule": "^0.5.0"
       }
     },
-    "react-emotion": {
-      "version": "9.2.10",
-      "resolved": "https://registry.npmjs.org/react-emotion/-/react-emotion-9.2.10.tgz",
-      "integrity": "sha512-dKCKM4DR8rt4thB1cgoGoMAh3ivCOXTa3CKtvMXJXtYcgJQ4ZmYp4WZ0qYYxbAGhF7FBje6c+YHlQ4nTdrHzqg==",
-      "requires": {
-        "babel-plugin-emotion": "^9.2.10",
-        "create-emotion-styled": "^9.2.8"
-      }
-    },
     "react-error-overlay": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
       "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
-    },
-    "react-frame-component": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-2.0.2.tgz",
-      "integrity": "sha1-5gKpgOHXj5H0cVMSJbYc/b9o5hQ="
     },
     "react-helmet": {
       "version": "5.2.0",
@@ -15609,132 +15614,10 @@
         "shallowequal": "^1.0.2"
       }
     },
-    "react-immutable-proptypes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz",
-      "integrity": "sha1-Aj1vObsVyXwHHp5g0A0TbqxfoLQ="
-    },
-    "react-is": {
-      "version": "16.3.1",
-      "resolved": "http://registry.npmjs.org/react-is/-/react-is-16.3.1.tgz",
-      "integrity": "sha512-3XpazGqS5DEOLiuR6JQ2Sg6URq/33d1BHJVaUvtMz579KRhd2D0pqabNEe5czv785yzKBPZimOf0UNIXa3jw1A=="
-    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
-    "react-modal": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
-      "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
-      "requires": {
-        "exenv": "^1.2.0",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
-      }
-    },
-    "react-onclickoutside": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz",
-      "integrity": "sha512-p84kBqGaMoa7VYT0vZ/aOYRfJB+gw34yjpda1Z5KeLflg70HipZOT+MXQenEhdkPAABuE2Astq4zEPdMqUQxcg=="
-    },
-    "react-portal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-3.2.0.tgz",
-      "integrity": "sha512-avb1FreAZAVCvNNyS2dCpxZiPYPJnAasHYPxdVBTROgNFeI+KSb+OoMHNsC1GbDawESCriPwCX+qKua6WSPIFw==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
-    "react-redux": {
-      "version": "4.4.9",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-4.4.9.tgz",
-      "integrity": "sha512-3XS7mjTOcvaP2H5OE/LxEgDHRuEyTZxBRlwvXHzNqYkZdYd7Ra98AimWoDSHP9OcLoydjA1ocgiZxxcqeXj0Sw==",
-      "requires": {
-        "create-react-class": "^15.5.1",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.0.0",
-        "lodash": "^4.2.0",
-        "loose-envify": "^1.1.0",
-        "prop-types": "^15.5.4"
-      }
-    },
-    "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
-      "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
-      "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-router-redux": {
-      "version": "5.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/react-router-redux/-/react-router-redux-5.0.0-alpha.9.tgz",
-      "integrity": "sha512-euSgNIANnRXr4GydIuwA7RZCefrLQzIw5WdXspS8NPYbV+FxrKSS9MKG7U9vb6vsKHONnA4VxrVNWfnMUnUQAw==",
-      "requires": {
-        "history": "^4.7.2",
-        "prop-types": "^15.6.0",
-        "react-router": "^4.2.0"
-      }
-    },
-    "react-scroll-sync": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-scroll-sync/-/react-scroll-sync-0.6.0.tgz",
-      "integrity": "sha512-Frc7pNPIEQY6rUAUwm1wW0an57Xau6X1Sag+Ra2FJT+oDBEBdh4cahrE3oGwtYHPcyWMt74q7vRKLw73cPy6aw=="
     },
     "react-side-effect": {
       "version": "1.1.5",
@@ -15743,92 +15626,6 @@
       "requires": {
         "exenv": "^1.2.1",
         "shallowequal": "^1.0.1"
-      }
-    },
-    "react-sortable-hoc": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
-      "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "invariant": "^2.2.1",
-        "lodash": "^4.12.0",
-        "prop-types": "^15.5.7"
-      }
-    },
-    "react-split-pane": {
-      "version": "0.1.84",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.84.tgz",
-      "integrity": "sha512-rso1dRAXX/WETyqF5C0fomIYzpF71Nothfr1R7pFkrJCPVJ20ok2e6wqF+JvUTyE/meiBvsbNPT1loZjyU+53w==",
-      "requires": {
-        "inline-style-prefixer": "^3.0.6",
-        "prop-types": "^15.5.10",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-style-proptype": "^3.0.0"
-      }
-    },
-    "react-style-proptype": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
-      "integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
-      "requires": {
-        "prop-types": "^15.5.4"
-      }
-    },
-    "react-textarea-autosize": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-5.2.1.tgz",
-      "integrity": "sha512-bx6z2I35aapr71ggw2yZIA4qhmqeTa4ZVsSaTeFvtf9kfcZppDBh2PbMt8lvbdmzEk7qbSFhAxR9vxEVm6oiMg==",
-      "requires": {
-        "prop-types": "^15.6.0"
-      }
-    },
-    "react-themeable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-themeable/-/react-themeable-1.1.0.tgz",
-      "integrity": "sha1-fURm3ZsrX6dQWHJ4JenxUro3mg4=",
-      "requires": {
-        "object-assign": "^3.0.0"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-        }
-      }
-    },
-    "react-toggled": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/react-toggled/-/react-toggled-1.2.7.tgz",
-      "integrity": "sha512-3am1uA5ZzDwUkReEuUkK+fJ0DAYcGiLraWEPqXfL1kKD/NHbbB7fB/t+5FflMGd+FA6n9hih1es4pui1yzKi0w=="
-    },
-    "react-topbar-progress-indicator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-topbar-progress-indicator/-/react-topbar-progress-indicator-2.0.0.tgz",
-      "integrity": "sha512-QEKsnwkjMvb10h7k+cFm0UeeVcRRIGhOJNqMQAbDyzSifPvlePk0KIcUb9dof2SkW7E5GaSxGsmXSpaFTYn43A==",
-      "requires": {
-        "topbar": "^0.1.3"
-      }
-    },
-    "react-transition-group": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
-      "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
-      "requires": {
-        "dom-helpers": "^3.3.1",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "react-waypoint": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-7.3.4.tgz",
-      "integrity": "sha1-b0oWfKccCHdXZpnWmACJ8AETf5A=",
-      "requires": {
-        "consolidated-events": "^1.1.0",
-        "prop-types": "^15.0.0"
       }
     },
     "read": {
@@ -15958,41 +15755,6 @@
         "symbol-observable": "^1.0.3"
       }
     },
-    "redux-notifications": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/redux-notifications/-/redux-notifications-4.0.1.tgz",
-      "integrity": "sha512-mRVaEcsvu5B4P8x8kW0uY83EQqaWL/0+/NvL4bdbHGJVg+Rwx54MgBU1s+tB6RAA2E6NX/DmQrO4EbFDcQSi+w==",
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.10",
-        "react-redux": "^4.0.0",
-        "react-transition-group": "^1.1.3"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-          "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
-          "requires": {
-            "chain-function": "^1.0.0",
-            "dom-helpers": "^3.2.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.5.6",
-            "warning": "^3.0.0"
-          }
-        }
-      }
-    },
-    "redux-optimist": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-0.0.2.tgz",
-      "integrity": "sha1-cNoX6GPFOoYE1YHKIKJpCL2haX4="
-    },
-    "redux-thunk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-1.0.3.tgz",
-      "integrity": "sha1-d4qgCZ7qBZUDGrazkWX2Zw2NJr0="
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -16090,77 +15852,6 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
       }
-    },
-    "rehype-minify-whitespace": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-2.0.3.tgz",
-      "integrity": "sha512-KzOH3F92J7Wvr3WuaqSO69FuN+vwbitVYxdSolLXrwLwdo67VXn/qSYGR7gnYDJKgfm/+m3l8hZHY43Zg+YscQ==",
-      "requires": {
-        "collapse-white-space": "^1.0.0",
-        "hast-util-embedded": "^1.0.0",
-        "hast-util-has-property": "^1.0.0",
-        "hast-util-is-body-ok-link": "^1.0.0",
-        "hast-util-is-element": "^1.0.0",
-        "html-whitespace-sensitive-tag-names": "^1.0.0",
-        "unist-util-is": "^2.0.0",
-        "unist-util-modify-children": "^1.0.0"
-      }
-    },
-    "rehype-parse": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-3.1.0.tgz",
-      "integrity": "sha1-f1InpZej85/EuThkYWFTnERO5yg=",
-      "requires": {
-        "hast-util-from-parse5": "^1.0.0",
-        "parse5": "^2.1.5",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "hast-util-from-parse5": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-1.1.0.tgz",
-          "integrity": "sha1-NZzDOdyMzx36ykGRWtY/1UYTCs0=",
-          "requires": {
-            "camelcase": "^3.0.0",
-            "has": "^1.0.1",
-            "hastscript": "^3.0.0",
-            "property-information": "^3.1.0",
-            "vfile-location": "^2.0.0"
-          }
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY="
-        }
-      }
-    },
-    "rehype-remark": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-2.1.0.tgz",
-      "integrity": "sha1-hMrdQUENI96Pg+FB6SNCwt+Uwcg=",
-      "requires": {
-        "hast-util-to-mdast": "^1.1.0"
-      }
-    },
-    "rehype-stringify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-3.0.0.tgz",
-      "integrity": "sha1-n+8IaCE8Lc4veAt289BIjIXoGes=",
-      "requires": {
-        "hast-util-to-html": "^3.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
     "relay-compiler": {
       "version": "1.5.0",
@@ -16308,34 +15999,6 @@
         "xtend": "^4.0.1"
       }
     },
-    "remark-rehype": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-2.0.1.tgz",
-      "integrity": "sha1-E+mJ+J7hVES9I1Tf/XZ9qSK5heM=",
-      "requires": {
-        "mdast-util-to-hast": "^2.2.0"
-      },
-      "dependencies": {
-        "mdast-util-to-hast": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-2.5.0.tgz",
-          "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
-          "requires": {
-            "collapse-white-space": "^1.0.0",
-            "detab": "^2.0.0",
-            "mdast-util-definitions": "^1.2.0",
-            "mdurl": "^1.0.1",
-            "trim": "0.0.1",
-            "trim-lines": "^1.0.0",
-            "unist-builder": "^1.0.1",
-            "unist-util-generated": "^1.1.0",
-            "unist-util-position": "^3.0.0",
-            "unist-util-visit": "^1.1.0",
-            "xtend": "^4.0.1"
-          }
-        }
-      }
-    },
     "remark-retext": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-retext/-/remark-retext-3.1.1.tgz",
@@ -16461,6 +16124,11 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
+    "require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -16511,11 +16179,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
-    },
-    "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -16630,14 +16293,6 @@
       "integrity": "sha512-nDwXOhiheoaBT6op02n8wzsshjLXHhh4YAeqsDEoVmy1k2+lGv/ENLsGaWqkaKArUkUx48VO12/ZPa3sI/OEqQ==",
       "requires": {
         "clones": "^1.1.0"
-      }
-    },
-    "sanitize-filename": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
-      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
-      "requires": {
-        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "sanitize-html": {
@@ -16937,11 +16592,6 @@
         }
       }
     },
-    "section-iterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
-      "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio="
-    },
     "section-matter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -16984,11 +16634,6 @@
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
-    "selection-is-backward": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/selection-is-backward/-/selection-is-backward-1.0.0.tgz",
-      "integrity": "sha1-l6VGMxiKURq6ZBn8XB+pG0Z+a+E="
-    },
     "selfsigned": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
@@ -16996,11 +16641,6 @@
       "requires": {
         "node-forge": "0.7.5"
       }
-    },
-    "semaphore": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
-      "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
       "version": "5.5.1",
@@ -17199,11 +16839,6 @@
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
-    "shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.0.0.tgz",
-      "integrity": "sha1-UI0YOLPeWQq4dXsBGyXkMJAJRfc="
-    },
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -17304,107 +16939,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-    },
-    "slate": {
-      "version": "0.34.7",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.34.7.tgz",
-      "integrity": "sha1-WQjh0PwJKiISSIvsplZx8B4OuAo=",
-      "requires": {
-        "debug": "^3.1.0",
-        "direction": "^0.1.5",
-        "esrever": "^0.2.0",
-        "is-empty": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "lodash": "^4.17.4",
-        "slate-dev-logger": "^0.1.39",
-        "slate-schema-violations": "^0.1.20",
-        "type-of": "^2.0.1"
-      }
-    },
-    "slate-base64-serializer": {
-      "version": "0.2.67",
-      "resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.67.tgz",
-      "integrity": "sha512-sZAzS07Cn1VRo4448SJpSU9WhRqOJnAV1JbJdghBhnjLU+IXQAgZTgXPwlp/jIa6jcW9wr4bLZ/uqTPiuOzzDA==",
-      "requires": {
-        "isomorphic-base64": "^1.0.2"
-      }
-    },
-    "slate-dev-environment": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/slate-dev-environment/-/slate-dev-environment-0.1.6.tgz",
-      "integrity": "sha512-DDeNzcpBvdEtPmuLrpPtrth7vnK693fgxzwS6FACu3oMBoXjh0qcJWVBktecPJXJDxcTVkWUpt0dPhfXLMIkWQ==",
-      "requires": {
-        "is-in-browser": "^1.1.3"
-      }
-    },
-    "slate-dev-logger": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/slate-dev-logger/-/slate-dev-logger-0.1.43.tgz",
-      "integrity": "sha512-GkcPMGzmPVm85AL+jaKnzhIA0UH9ktQDEIDM+FuQtz+TAPcpPCQiRAaZ6I2p2uD0Hq9bImhKSCtHIa0qRxiVGw=="
-    },
-    "slate-edit-list": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/slate-edit-list/-/slate-edit-list-0.11.3.tgz",
-      "integrity": "sha512-nqaiYYppezMmbsh+JN6vqZl2EexiUTJWwCzJVas8cv+WeRtRmuysn94LKF2VdLIxLmNAe/ZfliIkW9uC/NdO6w=="
-    },
-    "slate-edit-table": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/slate-edit-table/-/slate-edit-table-0.15.2.tgz",
-      "integrity": "sha1-8mtnRRtQf5NhBhUfVaC/+9vKAhM="
-    },
-    "slate-hotkeys": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/slate-hotkeys/-/slate-hotkeys-0.1.4.tgz",
-      "integrity": "sha1-WxCyoXiv/GCCf5KE1MCl1+UEH/4=",
-      "requires": {
-        "is-hotkey": "^0.1.1",
-        "slate-dev-environment": "^0.1.4"
-      }
-    },
-    "slate-plain-serializer": {
-      "version": "0.5.41",
-      "resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.5.41.tgz",
-      "integrity": "sha512-KPC2T5PT29JN7uxpmpg/xIGO1YjNmpTfghkGsUKBx7HHYjGe5c9jEApolTvzNy3F3w+wGQNsiT+aN6dn9m6sFA==",
-      "requires": {
-        "slate-dev-logger": "^0.1.43"
-      }
-    },
-    "slate-prop-types": {
-      "version": "0.4.65",
-      "resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.4.65.tgz",
-      "integrity": "sha512-QpoQkSKdh6yWvL2KqN+ky6KT+ng0jLR7PWi5O/x7A3LpomVnHlZeYPEpLhNOOjoAjBA1Dcnbaz/lw2Avi6MUhA=="
-    },
-    "slate-react": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.12.9.tgz",
-      "integrity": "sha1-bLbx+obIaPVrXc4GQUZSBUWIQ1E=",
-      "requires": {
-        "debug": "^3.1.0",
-        "get-window": "^1.1.1",
-        "is-window": "^1.0.2",
-        "keycode": "^2.1.2",
-        "lodash": "^4.1.1",
-        "prop-types": "^15.5.8",
-        "react-immutable-proptypes": "^2.1.0",
-        "react-portal": "^3.1.0",
-        "selection-is-backward": "^1.0.0",
-        "slate-base64-serializer": "^0.2.34",
-        "slate-dev-environment": "^0.1.2",
-        "slate-dev-logger": "^0.1.39",
-        "slate-hotkeys": "^0.1.2",
-        "slate-plain-serializer": "^0.5.15",
-        "slate-prop-types": "^0.4.32"
-      }
-    },
-    "slate-schema-violations": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/slate-schema-violations/-/slate-schema-violations-0.1.39.tgz",
-      "integrity": "sha512-SNRoV9Ii5UqjNqAKcIw7aAOMwgI45zsn86ue2n8NVLNOCe3fUI35cjq6l3fdvmRYw4X/GcZqzhpQsizHD3ts6A=="
-    },
-    "slate-soft-break": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/slate-soft-break/-/slate-soft-break-0.6.1.tgz",
-      "integrity": "sha512-PTujwU6B8vKO86Yqj2TXcryxkal6PBmFrUhZwZF6fQlhlLUaJAMYQX60blGvO7tncDxyofxxIkBKdGdjL3JldA=="
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -18235,16 +17769,6 @@
         }
       }
     },
-    "stylis": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.3.tgz",
-      "integrity": "sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ=="
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
-    },
     "sum-up": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
@@ -18407,11 +17931,6 @@
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
       }
-    },
-    "teeny-tap": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/teeny-tap/-/teeny-tap-0.2.0.tgz",
-      "integrity": "sha1-Fn5kUYLQasIi1iuyq2eUenClimg="
     },
     "temp-dir": {
       "version": "1.0.0",
@@ -18742,20 +18261,10 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
     },
-    "toml-j0.4": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/toml-j0.4/-/toml-j0.4-1.1.1.tgz",
-      "integrity": "sha512-lYK5otg0+cto8YmsWcPEfeiTiC/VU6P6HA6ooaYI9K/KYT24Jg0BrYtRZK1K3cwakSMyh6nttfJL9RmQH0gyCg=="
-    },
     "tomlify-j0.4": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tomlify-j0.4/-/tomlify-j0.4-3.0.0.tgz",
       "integrity": "sha512-2Ulkc8T7mXJ2l0W476YC/A209PR38Nw8PuaCNtk9uI3t1zzFdGQeWYGQvmj2PZkVvRC/Yoi4xQKMRnWc/N29tQ=="
-    },
-    "topbar": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/topbar/-/topbar-0.1.3.tgz",
-      "integrity": "sha1-ye+HdtxEafeEDmQW9BNt3sz0t8Y="
     },
     "topo": {
       "version": "2.0.2",
@@ -18763,19 +18272,6 @@
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
-      }
-    },
-    "toposort": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
-      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk="
-    },
-    "touch": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
-      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
-      "requires": {
-        "nopt": "~1.0.10"
       }
     },
     "tough-cookie": {
@@ -18838,14 +18334,6 @@
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "requires": {
         "glob": "^7.1.2"
-      }
-    },
-    "truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "requires": {
-        "utf8-byte-length": "^1.0.1"
       }
     },
     "tslib": {
@@ -19356,11 +18844,6 @@
         "xdg-basedir": "^3.0.0"
       }
     },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -19485,11 +18968,6 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
-    "utf8-byte-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
-    },
     "util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -19550,11 +19028,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -20163,11 +19636,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
-    "what-input": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/what-input/-/what-input-5.1.2.tgz",
-      "integrity": "sha512-heakW2Fi+dlbRGzTqM4H0dsH5WQGX56fFs3Rcp09tQS4CPLDkn1HMzf1z7Fc9+ZrwAaMP0QBGQIA8FBuMNrFeQ=="
-    },
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
@@ -20210,6 +19678,23 @@
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "requires": {
         "string-width": "^2.1.1"
+      }
+    },
+    "with-open-file": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.5.tgz",
+      "integrity": "sha512-zY51cJCXG6qBilVuMceKNwU3rzjB/Ygt96BuSQ4+tXo3ewlxvj9ET99lpUHNzWfkYmsyfqKZEB9NJORmGZ1Ltw==",
+      "requires": {
+        "p-finally": "^1.0.0",
+        "p-try": "^2.0.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gatsby-awesome-pagination": "^0.3.3",
     "gatsby-plugin-lodash": "^3.0.1",
     "gatsby-plugin-netlify": "^2.0.0",
-    "gatsby-plugin-purgecss": "^2.4.0",
+    "gatsby-plugin-purgecss": "^3.1.0",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-sass": "^2.0.1",
     "gatsby-plugin-sharp": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5869,10 +5869,10 @@ gatsby-plugin-page-creator@^2.0.0:
     parse-filepath "^1.0.1"
     slash "^1.0.0"
 
-gatsby-plugin-purgecss@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-2.4.0.tgz#2cfe4c3ad4727fcaa3191ba53867fc5d21a14601"
-  integrity sha512-1fIuZGYNavcEkEQk/PbenbazqFxeSLDODO+PQT9UWoe9X/9u4F/nv8a8Az7J1dtdVDIQEqWdgonpQFJXmMClbA==
+gatsby-plugin-purgecss@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-purgecss/-/gatsby-plugin-purgecss-3.1.0.tgz#ecaf5266317ef3deba94478f341f2855f58a3a74"
+  integrity sha512-X8715ZuRmusyEIE91EA+4SS3yvw986kV0h4atB6Tsz5rE8n9KqzPMQxrVsJGRuI5DIxu0YZN6EEFlb7UMTT3cg==
   dependencies:
     fs-extra "^7.0.0"
     loader-utils "^1.1.0"


### PR DESCRIPTION
https://github.com/GatsbyCentral/gatsby-starter-wordpress/issues/40
Updated `gatsby-plugin-purgecss` to latest major version. (needed for newer options)
Enabled purging when running `gatsby develop`.
Specify to purge only `all.sass` file.

**Sidenote:** I see that the lock files are very old, which force installs the older version of the packages.
  
![audit](https://user-images.githubusercontent.com/12339068/54026579-58c1c480-41c4-11e9-8b47-96d70ac5ab3f.jpg)
![image](https://user-images.githubusercontent.com/12339068/54026956-b9053600-41c5-11e9-9dce-155f5d3a52bc.png)

I would be better to not use lockfiles in this starter or maintain updated lockfiles using renovate, greenkeeper or dependabot.