### PR TITLE
Create nested paths for Pages and use wordpress paths for rest

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,7 +15,6 @@ exports.createPages = ({ actions, graphql }) => {
         edges {
           node {
             id
-            
             status
             path
           }
@@ -59,7 +58,6 @@ exports.createPages = ({ actions, graphql }) => {
             edges {
               node {
                 id
-                
                 status
                 path
               }
@@ -113,7 +111,6 @@ exports.createPages = ({ actions, graphql }) => {
               node {
                 id
                 name
-                
                 path
               }
             }
@@ -149,7 +146,6 @@ exports.createPages = ({ actions, graphql }) => {
               node {
                 id
                 name
-                
                 path
               }
             }
@@ -184,8 +180,7 @@ exports.createPages = ({ actions, graphql }) => {
           allWordpressWpUsers {
             edges {
               node {
-                id
-                
+                id 
                 path
               }
             }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,8 +15,9 @@ exports.createPages = ({ actions, graphql }) => {
         edges {
           node {
             id
-            slug
+            
             status
+            path
           }
         }
       }
@@ -43,7 +44,7 @@ exports.createPages = ({ actions, graphql }) => {
       // Call `createPage()` once per WordPress page
       _.each(pages, ({ node: page }) => {
         createPage({
-          path: `/${page.slug}/`,
+          path: `${page.path}`,
           component: pageTemplate,
           context: {
             id: page.id,
@@ -58,8 +59,9 @@ exports.createPages = ({ actions, graphql }) => {
             edges {
               node {
                 id
-                slug
+                
                 status
+                path
               }
             }
           }
@@ -86,7 +88,7 @@ exports.createPages = ({ actions, graphql }) => {
       _.each(posts, ({ node: post }) => {
         // Create the Gatsby page for this WordPress post
         createPage({
-          path: `/${post.slug}/`,
+          path: `${post.path}`,
           component: postTemplate,
           context: {
             id: post.id,
@@ -111,7 +113,8 @@ exports.createPages = ({ actions, graphql }) => {
               node {
                 id
                 name
-                slug
+                
+                path
               }
             }
           }
@@ -129,11 +132,11 @@ exports.createPages = ({ actions, graphql }) => {
       // Create a Gatsby page for each WordPress Category
       _.each(result.data.allWordpressCategory.edges, ({ node: cat }) => {
         createPage({
-          path: `/categories/${cat.slug}/`,
+          path: `${cat.path}`,
           component: categoriesTemplate,
           context: {
             name: cat.name,
-            slug: cat.slug,
+            slug: cat.path,
           },
         })
       })
@@ -146,7 +149,8 @@ exports.createPages = ({ actions, graphql }) => {
               node {
                 id
                 name
-                slug
+                
+                path
               }
             }
           }
@@ -165,11 +169,11 @@ exports.createPages = ({ actions, graphql }) => {
       // Create a Gatsby page for each WordPress tag
       _.each(result.data.allWordpressTag.edges, ({ node: tag }) => {
         createPage({
-          path: `/tags/${tag.slug}/`,
+          path: `${tag.path}`,
           component: tagsTemplate,
           context: {
             name: tag.name,
-            slug: tag.slug,
+            slug: tag.path,
           },
         })
       })
@@ -181,7 +185,8 @@ exports.createPages = ({ actions, graphql }) => {
             edges {
               node {
                 id
-                slug
+                
+                path
               }
             }
           }
@@ -198,7 +203,7 @@ exports.createPages = ({ actions, graphql }) => {
 
       _.each(result.data.allWordpressWpUsers.edges, ({ node: author }) => {
         createPage({
-          path: `/author/${author.slug}`,
+          path: `${author.path}`,
           component: authorTemplate,
           context: {
             id: author.id,

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -11,7 +11,6 @@ const Navbar = () => (
           edges {
             node {
               title
-              
               path
             }
           }

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -11,7 +11,8 @@ const Navbar = () => (
           edges {
             node {
               title
-              slug
+              
+              path
             }
           }
         }
@@ -31,8 +32,8 @@ const Navbar = () => (
             {data.allWordpressPage.edges.map(edge => (
               <Link
                 className="navbar-item"
-                to={edge.node.slug}
-                key={edge.node.slug}
+                to={edge.node.path}
+                key={edge.node.path}
               >
                 {edge.node.title}
               </Link>

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -63,14 +63,12 @@ export const pageQuery = graphql`
     excerpt
     author {
       name
-      
       path
       avatar_urls {
         wordpress_48
       }
     }
     date(formatString: "MMMM DD, YYYY")
-    
     path
   }
 `

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -19,13 +19,16 @@ export default class IndexPage extends React.Component {
               key={post.id}
             >
               <p>
-                <Link className="has-text-primary" to={post.slug}>
+                <Link className="has-text-primary" to={post.path}>
                   {post.title}
                 </Link>
                 <span> &bull; </span>
                 <small>
-                  {post.date} - posted by{' '}
-                  <Link to={`/author/${post.author.slug}`}>
+                  {post.date}
+                  {' '}
+- posted by
+                  {' '}
+                  <Link to={`/author/${post.author.path}`}>
                     {post.author.name}
                   </Link>
                 </small>
@@ -36,7 +39,7 @@ export default class IndexPage extends React.Component {
                     __html: post.excerpt.replace(/<p class="link-more.*/, ''),
                   }}
                 />
-                <Link className="button is-small" to={post.slug}>
+                <Link className="button is-small" to={post.path}>
                   Keep Reading →
                 </Link>
               </div>
@@ -60,12 +63,14 @@ export const pageQuery = graphql`
     excerpt
     author {
       name
-      slug
+      
+      path
       avatar_urls {
         wordpress_48
       }
     }
     date(formatString: "MMMM DD, YYYY")
-    slug
+    
+    path
   }
 `

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -24,14 +24,14 @@ const Category = props => {
 export default Category
 
 export const pageQuery = graphql`
-  query CategoryPage($slug: String!) {
+  query CategoryPage($path: String!) {
     site {
       siteMetadata {
         title
       }
     }
     allWordpressPost(
-      filter: { categories: { elemMatch: { slug: { eq: $slug } } } }
+      filter: { categories: { elemMatch: { path: { eq: $path } } } }
     ) {
       totalCount
       edges {

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -23,16 +23,19 @@ export const BlogPostTemplate = ({
             <div dangerouslySetInnerHTML={{ __html: content }} />
             <div style={{ marginTop: `4rem` }}>
               <p>
-                {date} - posted by{' '}
-                <Link to={`/author/${author.slug}`}>{author.name}</Link>
+                {date}
+                {' '}
+- posted by
+                {' '}
+                <Link to={`${author.path}`}>{author.name}</Link>
               </p>
               {categories && categories.length ? (
                 <div>
                   <h4>Categories</h4>
                   <ul className="taglist">
                     {categories.map(category => (
-                      <li key={`${category.slug}cat`}>
-                        <Link to={`/categories/${category.slug}/`}>
+                      <li key={`${category.path}`}>
+                        <Link to={`${category.path}`}>
                           {category.name}
                         </Link>
                       </li>
@@ -45,8 +48,8 @@ export const BlogPostTemplate = ({
                   <h4>Tags</h4>
                   <ul className="taglist">
                     {tags.map(tag => (
-                      <li key={`${tag.slug}tag`}>
-                        <Link to={`/tags/${tag.slug}/`}>{tag.name}</Link>
+                      <li key={`${tag.path}`}>
+                        <Link to={`${tag.path}/`}>{tag.name}</Link>
                       </li>
                     ))}
                   </ul>
@@ -94,7 +97,8 @@ export default BlogPost
 export const pageQuery = graphql`
   fragment PostFields on wordpress__POST {
     id
-    slug
+    
+    path
     content
     date(formatString: "MMMM DD, YYYY")
     title
@@ -103,20 +107,24 @@ export const pageQuery = graphql`
     wordpressPost(id: { eq: $id }) {
       id
       title
-      slug
+      
+      path
       content
       date(formatString: "MMMM DD, YYYY")
       categories {
         name
-        slug
+        
+        path
       }
       tags {
         name
-        slug
+        
+        path
       }
       author {
         name
-        slug
+        
+        path
       }
     }
   }

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -97,7 +97,6 @@ export default BlogPost
 export const pageQuery = graphql`
   fragment PostFields on wordpress__POST {
     id
-    
     path
     content
     date(formatString: "MMMM DD, YYYY")
@@ -107,23 +106,19 @@ export const pageQuery = graphql`
     wordpressPost(id: { eq: $id }) {
       id
       title
-      
       path
       content
       date(formatString: "MMMM DD, YYYY")
       categories {
         name
-        
         path
       }
       tags {
         name
-        
         path
       }
       author {
-        name
-        
+        name 
         path
       }
     }

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -24,13 +24,13 @@ const Tag = props => {
 export default Tag
 
 export const pageQuery = graphql`
-  query TagPage($slug: String!) {
+  query TagPage($path: String!) {
     site {
       siteMetadata {
         title
       }
     }
-    allWordpressPost(filter: { tags: { elemMatch: { slug: { eq: $slug } } } }) {
+    allWordpressPost(filter: { tags: { elemMatch: { path: { eq: $path } } } }) {
       totalCount
       edges {
         node {


### PR DESCRIPTION
closes #24 

This would cause breaking change as templates need to be updated. Could be done just to pages to avoid breaking changes since the current page template does not rely on slug

Changes
* Uses .path over .slug
* Creates nested pages
* Changes post to use the path setting in wordpress, so for the example site a post would be at http://localhost:8001/2018/10/04/sample-media-post/ 
This would change based on settings in wp
* Authors would be set up at author/name - which is the same as before but now in templates and gatsby-node it only needs ``` `${author.path}` over `/author/${slug}/` ```
* same with categories now at category/name Same pattern in the code