### PR TITLE
Fixing post slug URL in PostList component

### DIFF
--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -19,7 +19,7 @@ export default class IndexPage extends React.Component {
               key={post.id}
             >
               <p>
-                <Link className="has-text-primary" to={post.slug}>
+                <Link className="has-text-primary" to={`/${post.slug}`}>
                   {post.title}
                 </Link>
                 <span> &bull; </span>
@@ -36,7 +36,7 @@ export default class IndexPage extends React.Component {
                     __html: post.excerpt.replace(/<p class="link-more.*/, ''),
                   }}
                 />
-                <Link className="button is-small" to={post.slug}>
+                <Link className="button is-small" to={`/${post.slug}`}>
                   Keep Reading →
                 </Link>
               </div>


### PR DESCRIPTION
Current implementation appends slug to current url, which does not work for anything but the homepage.