### PR TITLE
remove lodash from getOnlyPublished()

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,8 +3,7 @@ const path = require('path')
 const { createFilePath } = require('gatsby-source-filesystem')
 const { paginate } = require('gatsby-awesome-pagination')
 
-const getOnlyPublished = edges =>
-  _.filter(edges, ({ node }) => node.status === 'publish')
+const getOnlyPublished = edges => edges.filter(edge => edge.node.status === 'publish');
 
 exports.createPages = ({ actions, graphql }) => {
   const { createPage } = actions


### PR DESCRIPTION
stick with vanilla JS, there's no real benefit to using lodash here is there?